### PR TITLE
Fixed Amb to manually call cancelUpstream

### DIFF
--- a/Sources/Operators/Amb.swift
+++ b/Sources/Operators/Amb.swift
@@ -103,8 +103,10 @@ private extension Publishers.Amb {
                 guard let decision = decision else { return }
                 switch decision {
                 case .first:
+                    secondSink?.cancelUpstream()
                     secondSink = nil
                 case .second:
+                    firstSink?.cancelUpstream()
                     firstSink = nil
                 }
 
@@ -144,7 +146,9 @@ private extension Publishers.Amb {
         }
 
         func cancel() {
+            firstSink?.cancelUpstream()
             firstSink = nil
+            secondSink?.cancelUpstream()
             secondSink = nil
         }
     }


### PR DESCRIPTION
This PR fixes Amb based on public PR here:
https://github.com/CombineCommunity/CombineExt/pull/144